### PR TITLE
allow Doom Spike -> Sonic Thrust, looping

### DIFF
--- a/PVE_DRAGOON.lua
+++ b/PVE_DRAGOON.lua
@@ -83,7 +83,7 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 			["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Line", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 10, ["MaxDistance"] = 10, ["LineWidth"] = 4, ["Angle"] = 0, },
 		},
 		{
-			["Type"] = 1, ["Name"] = "Doom Spike", ["ID"] = 86, ["ComboIDNOT"] = { [86] = true, [7397] = true, }, ["Range"] = 10, ["TargetCast"] = true, ["AOECount"] = 3, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false,
+			["Type"] = 1, ["Name"] = "Doom Spike", ["ID"] = 86, ["ComboIDNOT"] = { [86] = true, }, ["Range"] = 10, ["TargetCast"] = true, ["AOECount"] = 3, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false,
 			["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Line", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 10, ["MaxDistance"] = 10, ["LineWidth"] = 4, ["Angle"] = 0, },
 		},
 		{


### PR DESCRIPTION
Doom Spike was set to not allow comboing after Sonic Thrust, so at level 62 DRG it would do "Doom Spike, Sonic Thrust, **true thrust**" as its AOE loop.

Not sure if this breaks things at later levels, but the behavior at these levels is definitely wrong.