### PR TITLE
use Dream within a Dream during trick attack window, even if the enemy doesn't have the debuff

### DIFF
--- a/PVE_NINJA.lua
+++ b/PVE_NINJA.lua
@@ -386,7 +386,7 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 			["Type"] = 1, ["Name"] = "Throwing Dagger", ["ID"] = 2247, ["Range"] = 25, ["TargetCast"] = true, ["OtherCheck"] = self.NinjaLastMudra == 0 and LastActionWasMudra == false, ["Buff"] = HasMudraBuff == false and HasTenChiJinBuff == false,
 		},
 		{
-			["Type"] = 1, ["Name"] = "Dream Within a Dream", ["ID"] = 3566, ["Range"] = 3, ["TargetCast"] = true, ["OtherCheck"] = self.NinjaLastMudra == 0 and LastActionWasMudra == false, ["Buff"] = HasMudraBuff == false and HasTenChiJinBuff == false and TargetHasTrickAttack == true,
+			["Type"] = 1, ["Name"] = "Dream Within a Dream", ["ID"] = 3566, ["Range"] = 3, ["TargetCast"] = true, ["OtherCheck"] = self.NinjaLastMudra == 0 and LastActionWasMudra == false and TrickAttack.isoncd and TrickAttack.cd < 15, ["Buff"] = HasMudraBuff == false and HasTenChiJinBuff == false,
 		},
 
 		{


### PR DESCRIPTION
Because of the way the Nin profile is laid out, mudras have the highest precedence. So trick attack windows start with a mudra, which in lots of dungeon content kills your current trick attack target. This results in sitting on Dream within a Dream more often than not. 

This keeps the intent of aligning Dream with the window, but allows it to be on a separate target.