### PR TITLE
DT GNB additions and rotational improvements

### DIFF
--- a/PVE_GUNBREAKER_DT.lua
+++ b/PVE_GUNBREAKER_DT.lua
@@ -205,6 +205,11 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 			["Type"] = 1, ["Name"] = "Eye Gouge", ["ID"] = 16158, ["Range"] = 3, ["TargetCast"] = true,
 		},
 		{
+			["Type"] = 2, ["Name"] = "Fated Brand", ["ID"] = 36936, ["Range"] = 0, ["TargetCast"] = false,
+			["AOECount"] = 1, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false,
+			["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, },
+		},
+		{
 			["Type"] = 1, ["Name"] = "Hypervelocity", ["ID"] = 25759, ["Range"] = 3, ["TargetCast"] = true,
 		},
 		{

--- a/PVE_GUNBREAKER_DT.lua
+++ b/PVE_GUNBREAKER_DT.lua
@@ -124,8 +124,11 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 	local Bloodfest = ActionList:Get(1,16164)
 	local NoMercy = ActionList:Get(1,16138)
 	local GnashingFang = ActionList:Get(1,16146)
+	
+	local HasNoMercyBuff = self.TargetBuff2(Player,1831,0,"Has",PlayerID)
 
 	local MaxCartridges = PlayerLevel >= 88 and 3 or 2
+	local HasBloodfest = PlayerLevel >= 76
 
 	local SkillList = {
 		{
@@ -158,12 +161,12 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 		{
 			["Type"] = 2, ["Name"] = "Double Down Burn", ["ID"] = 25760, ["Range"] = 0, ["TargetCast"] = false, ["GaugeCheck"] = GaugeData1[1] >= 2, ["AOECount"] = 1, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DDBurn") == 2 and AOETimeout == false,
 			["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, },
-			["Buff"] = self.TargetBuff2(Player,1831,0,"Has",PlayerID),
+			["Buff"] = HasNoMercyBuff,
 		},
 		{
 			["Type"] = 2, ["Name"] = "Bow Shock Burn", ["ID"] = 16159, ["Range"] = 0, ["TargetCast"] = false, ["AOECount"] = 1, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DDBurn") == 2 and AOETimeout == false,
 			["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, },
-			["Buff"] = self.TargetBuff2(Player,1831,0,"Has",PlayerID),
+			["Buff"] = HasNoMercyBuff,
 		},
 		{
 			["Type"] = 1, ["Name"] = "Sonic Break", ["ID"] = 16153, ["Range"] = 3, ["TargetCast"] = true,
@@ -184,10 +187,10 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 			["Type"] = 1, ["Name"] = "Gnashing Fang", ["ID"] = 16146, ["Range"] = 3, ["TargetCast"] = true, ["OtherCheck"] = NoMercy.isoncd and NoMercy.cd < 40, 
 		},
 		{
-			["Type"] = 1, ["Name"] = "Burst Strike Low Level", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = GaugeData1[1] >= MaxCartridges, ["OtherCheck"] = PlayerLevel < 76
+			["Type"] = 1, ["Name"] = "Burst Strike Low Level", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = GaugeData1[1] >= MaxCartridges, ["OtherCheck"] = not HasBloodfest
 		},
 		{
-			["Type"] = 1, ["Name"] = "Burst Strike High Level", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = (GaugeData1[1] >= MaxCartridges and Bloodfest.cd > 20) or not Bloodfest.isoncd or Bloodfest.cd > 100, ["OtherCheck"] = PlayerLevel >= 76
+			["Type"] = 1, ["Name"] = "Burst Strike High Level", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = (GaugeData1[1] >= MaxCartridges and Bloodfest.cd > 20) or not Bloodfest.isoncd or Bloodfest.cd > 100, ["OtherCheck"] = HasBloodfest
 		},
 		{
 			["Type"] = 1, ["Name"] = "Jugular Rip", ["ID"] = 16156, ["Range"] = 3, ["TargetCast"] = true,

--- a/PVE_GUNBREAKER_DT.lua
+++ b/PVE_GUNBREAKER_DT.lua
@@ -123,6 +123,7 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 	]]--
 	local Bloodfest = ActionList:Get(1,16164)
 	local NoMercy = ActionList:Get(1,16138)
+	local GnashingFang = ActionList:Get(1,16146)
 
 	local MaxCartridges = PlayerLevel >= 88 and 3 or 2
 
@@ -171,6 +172,14 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 			["Type"] = 2, ["Name"] = "Fated Circle", ["ID"] = 16163, ["Range"] = 0, ["TargetCast"] = false, ["AOECount"] = 3, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false,
 			["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, }, ["GaugeCheck"] = GaugeData1[1] >= 2,
 		},
+		--[[ Finish Lion Heart combo if already started --]]
+		{
+			["Type"] = 1, ["Name"] = "Noble Blood", ["ID"] = 36938, ["Range"] = 3, ["TargetCast"] = true,
+		},
+		{
+			["Type"] = 1, ["Name"] = "Lion Heart", ["ID"] = 36939, ["Range"] = 3, ["TargetCast"] = true,
+		},
+		--[[ Prefer starting GF to starting Lion Heart -- ]]
 		{
 			["Type"] = 1, ["Name"] = "Gnashing Fang", ["ID"] = 16146, ["Range"] = 3, ["TargetCast"] = true, ["OtherCheck"] = NoMercy.isoncd and NoMercy.cd < 40, 
 		},
@@ -194,6 +203,9 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 		},
 		{
 			["Type"] = 1, ["Name"] = "Hypervelocity", ["ID"] = 25759, ["Range"] = 3, ["TargetCast"] = true,
+		},
+		{
+			["Type"] = 1, ["Name"] = "Reign of Beasts", ["ID"] = 36937, ["Range"] = 3, ["TargetCast"] = true, ["OtherCheck"] = GnashingFang.isoncd
 		},
 
         -- AOE

--- a/PVE_GUNBREAKER_DT.lua
+++ b/PVE_GUNBREAKER_DT.lua
@@ -23,6 +23,13 @@ Profile.Settings = {
         },
     },
     {
+        ["Setting"] = "Reprisal",
+        ["Options"] = {
+            { ["Name"] = "Reprisal", ["Tooltip"] = "Reprisal On", ["Colour"] = { ["r"] = 0, ["g"] = 1, ["b"] = 0, ["a"] = 1 }, },
+            { ["Name"] = "Reprisal", ["Tooltip"] = "Reprisal Off", ["Colour"] = { ["r"] = 1, ["g"] = 0, ["b"] = 0, ["a"] = 1 }, },
+        },
+    },
+    {
         ["Setting"] = "Superbolide",
         ["Options"] = {
             { ["Name"] = "Superbolide", ["Tooltip"] = "Superbolide On", ["Colour"] = { ["r"] = 0, ["g"] = 1, ["b"] = 0, ["a"] = 1 }, },
@@ -289,6 +296,12 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 		},
 		{
 			["Type"] = 1, ["Name"] = "Reprisal", ["ID"] = 7535, ["Range"] = 5, ["TargetCast"] = true, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1,
+		},
+		{
+			["Type"] = 2, ["Name"] = "Reprisal", ["ID"] = 7535, ["Range"] = 0, ["TargetCast"] = false,
+			["OtherCheck"] = PlayerHP <= 80 and PlayerInCombat == true, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and self.GetSettingsValue(ClassTypeID,"Reprisal") == 1 and AOETimeout == false,
+			["AOECount"] = 3,
+			["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, },
 		},
 		{
 			["Type"] = 1, ["Name"] = "Rampart", ["ID"] = 7531, ["Range"] = 0, ["TargetCast"] = false, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["OtherCheck"] = PlayerHP < 75 and PlayerInCombat == true,

--- a/PVE_GUNBREAKER_DT.lua
+++ b/PVE_GUNBREAKER_DT.lua
@@ -32,10 +32,10 @@ Profile.Settings = {
     {
         ["Setting"] = "Jumps",
         ["Options"] = {
-            { ["Name"] = "Jumps > 5", ["Tooltip"] = "Rough Divide > 5y", ["Colour"] = { ["r"] = 1, ["g"] = 0.6, ["b"] = 0, ["a"] = 1 }, },
-            { ["Name"] = "Jumps > 10", ["Tooltip"] = "Rough Divide > 10y", ["Colour"] = { ["r"] = 1, ["g"] = 1, ["b"] = 0, ["a"] = 1 }, },
-            { ["Name"] = "Jumps > 15", ["Tooltip"] = "Rough Divide > 15y", ["Colour"] = { ["r"] = 0, ["g"] = 1, ["b"] = 0, ["a"] = 1 }, },
-            { ["Name"] = "Jumps Off", ["Tooltip"] = "Rough Divide Off", ["Colour"] = { ["r"] = 1, ["g"] = 0, ["b"] = 0, ["a"] = 1 }, },
+            { ["Name"] = "Jumps > 5", ["Tooltip"] = "Trajectory > 5y", ["Colour"] = { ["r"] = 1, ["g"] = 0.6, ["b"] = 0, ["a"] = 1 }, },
+            { ["Name"] = "Jumps > 10", ["Tooltip"] = "Trajectory > 10y", ["Colour"] = { ["r"] = 1, ["g"] = 1, ["b"] = 0, ["a"] = 1 }, },
+            { ["Name"] = "Jumps > 15", ["Tooltip"] = "Trajectory > 15y", ["Colour"] = { ["r"] = 0, ["g"] = 1, ["b"] = 0, ["a"] = 1 }, },
+            { ["Name"] = "Jumps Off", ["Tooltip"] = "Trajectory Off", ["Colour"] = { ["r"] = 1, ["g"] = 0, ["b"] = 0, ["a"] = 1 }, },
         },
     },
     {
@@ -121,6 +121,10 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 		36938	Noble Blood
 		36939	Lion Heart
 	]]--
+	local Bloodfest = ActionList:Get(1,16164)
+	local NoMercy = ActionList:Get(1,16138)
+
+	local MaxCartridges = PlayerLevel >= 88 and 3 or 2
 
 	local SkillList = {
 		{
@@ -137,26 +141,28 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 			["Type"] = 1, ["Name"] = "Lighting Shot", ["ID"] = 16143, ["Range"] = 20, ["TargetCast"] = true, ["OtherCheck"] = TargetDistance > 3,
 		},
 		{
-			["Type"] = 1, ["Name"] = "Rough Divide", ["ID"] = 16154, ["Range"] = 20, ["TargetCast"] = true,  ["SettingValue"] = JumpTimeout == false and self.GetSettingsValue(ClassTypeID,"Jumps") ~= 4,
+			["Type"] = 1, ["Name"] = "Trajectory", ["ID"] = 36934, ["Range"] = 20, ["TargetCast"] = true,  ["SettingValue"] = JumpTimeout == false and self.GetSettingsValue(ClassTypeID,"Jumps") ~= 4,
 			["OtherCheck"] = (self.GetSettingsValue(ClassTypeID,"Jumps") == 1 and TargetDistance > 5) or (self.GetSettingsValue(ClassTypeID,"Jumps") == 2 and TargetDistance > 10) or (self.GetSettingsValue(ClassTypeID,"Jumps") == 3 and TargetDistance > 15),
 		},
 
 		{
-			["Type"] = 2, ["Name"] = "Double Down", ["ID"] = 25760, ["Range"] = 0, ["TargetCast"] = false, ["GaugeCheck"] = GaugeData1[1] >= 2, ["AOECount"] = 3, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false,
+			["Type"] = 2, ["Name"] = "Double Down", ["ID"] = 25760, ["Range"] = 0, ["TargetCast"] = false, ["GaugeCheck"] = GaugeData1[1] >= 2, ["AOECount"] = 3, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DDBurn") == 1,
             ["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, },
 		},
 		{
-			["Type"] = 2, ["Name"] = "Bow Shock", ["ID"] = 16159, ["Range"] = 0, ["TargetCast"] = false, ["AOECount"] = 3, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false,
+			["Type"] = 2, ["Name"] = "Bow Shock", ["ID"] = 16159, ["Range"] = 0, ["TargetCast"] = false, ["AOECount"] = 3, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DDBurn") == 1,
 			["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, },
 		},
 
 		{
 			["Type"] = 2, ["Name"] = "Double Down Burn", ["ID"] = 25760, ["Range"] = 0, ["TargetCast"] = false, ["GaugeCheck"] = GaugeData1[1] >= 2, ["AOECount"] = 1, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DDBurn") == 2 and AOETimeout == false,
 			["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, },
+			["Buff"] = self.TargetBuff2(Player,1831,0,"Has",PlayerID),
 		},
 		{
 			["Type"] = 2, ["Name"] = "Bow Shock Burn", ["ID"] = 16159, ["Range"] = 0, ["TargetCast"] = false, ["AOECount"] = 1, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DDBurn") == 2 and AOETimeout == false,
 			["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, },
+			["Buff"] = self.TargetBuff2(Player,1831,0,"Has",PlayerID),
 		},
 		{
 			["Type"] = 1, ["Name"] = "Sonic Break", ["ID"] = 16153, ["Range"] = 3, ["TargetCast"] = true,
@@ -166,7 +172,10 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 			["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, }, ["GaugeCheck"] = GaugeData1[1] >= 2,
 		},
 		{
-			["Type"] = 1, ["Name"] = "Gnashing Fang", ["ID"] = 16146, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = GaugeData1[1] >= 2,
+			["Type"] = 1, ["Name"] = "Gnashing Fang", ["ID"] = 16146, ["Range"] = 3, ["TargetCast"] = true, ["OtherCheck"] = NoMercy.isoncd and NoMercy.cd < 40, 
+		},
+		{
+			["Type"] = 1, ["Name"] = "Burst Strike", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = (GaugeData1[1] >= MaxCartridges and Bloodfest.cd > 20) or not Bloodfest.isoncd or Bloodfest.cd > 100,
 		},
 		{
 			["Type"] = 1, ["Name"] = "Jugular Rip", ["ID"] = 16156, ["Range"] = 3, ["TargetCast"] = true,
@@ -182,9 +191,6 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 		},
 		{
 			["Type"] = 1, ["Name"] = "Eye Gouge", ["ID"] = 16158, ["Range"] = 3, ["TargetCast"] = true,
-		},
-		{
-			["Type"] = 1, ["Name"] = "Burst Strike", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = GaugeData1[1] >= 2,
 		},
 		{
 			["Type"] = 1, ["Name"] = "Hypervelocity", ["ID"] = 25759, ["Range"] = 3, ["TargetCast"] = true,
@@ -216,9 +222,11 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 		},
 		{
 			["Type"] = 1, ["Name"] = "Danger Zone", ["ID"] = 16144, ["Range"] = 3, ["TargetCast"] = true,
+			["OtherCheck"] = NoMercy.isoncd and NoMercy.cd < 40,
 		},
 		{
 			["Type"] = 1, ["Name"] = "Blasting Zone", ["ID"] = 16165, ["Range"] = 3, ["TargetCast"] = true,
+			["OtherCheck"] = NoMercy.isoncd and NoMercy.cd < 40,
 		},
 		{
 			["Type"] = 1, ["Name"] = "No Mercy", ["ID"] = 16138, ["Range"] = 0, ["TargetCast"] = false, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["OtherCheck"] = PlayerInCombat == true,

--- a/PVE_GUNBREAKER_DT.lua
+++ b/PVE_GUNBREAKER_DT.lua
@@ -184,7 +184,10 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 			["Type"] = 1, ["Name"] = "Gnashing Fang", ["ID"] = 16146, ["Range"] = 3, ["TargetCast"] = true, ["OtherCheck"] = NoMercy.isoncd and NoMercy.cd < 40, 
 		},
 		{
-			["Type"] = 1, ["Name"] = "Burst Strike", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = (GaugeData1[1] >= MaxCartridges and Bloodfest.cd > 20) or not Bloodfest.isoncd or Bloodfest.cd > 100,
+			["Type"] = 1, ["Name"] = "Burst Strike Low Level", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = GaugeData1[1] >= MaxCartridges, ["OtherCheck"] = PlayerLevel < 76
+		},
+		{
+			["Type"] = 1, ["Name"] = "Burst Strike High Level", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = (GaugeData1[1] >= MaxCartridges and Bloodfest.cd > 20) or not Bloodfest.isoncd or Bloodfest.cd > 100, ["OtherCheck"] = PlayerLevel >= 76
 		},
 		{
 			["Type"] = 1, ["Name"] = "Jugular Rip", ["ID"] = 16156, ["Range"] = 3, ["TargetCast"] = true,

--- a/PVE_GUNBREAKER_DT.lua
+++ b/PVE_GUNBREAKER_DT.lua
@@ -121,14 +121,15 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 		36938	Noble Blood
 		36939	Lion Heart
 	]]--
-	local Bloodfest = ActionList:Get(1,16164)
-	local NoMercy = ActionList:Get(1,16138)
+	local BloodfestCD = self.GetActionCD(16164,true)
+	local NoMercySoon = self.GetActionCD(16138,false,20)
 	local GnashingFang = ActionList:Get(1,16146)
 	
 	local HasNoMercyBuff = self.TargetBuff2(Player,1831,0,"Has",PlayerID)
 
 	local MaxCartridges = PlayerLevel >= 88 and 3 or 2
 	local HasBloodfest = PlayerLevel >= 76
+	local HasDoubleDown = PlayerLevel >= 90
 
 	local SkillList = {
 		{
@@ -184,13 +185,13 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 		},
 		--[[ Prefer starting GF to starting Lion Heart -- ]]
 		{
-			["Type"] = 1, ["Name"] = "Gnashing Fang", ["ID"] = 16146, ["Range"] = 3, ["TargetCast"] = true, ["OtherCheck"] = NoMercy.isoncd and NoMercy.cd < 40, 
+			["Type"] = 1, ["Name"] = "Gnashing Fang", ["ID"] = 16146, ["Range"] = 3, ["TargetCast"] = true, ["OtherCheck"] = not NoMercySoon, 
 		},
 		{
-			["Type"] = 1, ["Name"] = "Burst Strike Low Level", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = GaugeData1[1] >= MaxCartridges, ["OtherCheck"] = not HasBloodfest
+			["Type"] = 1, ["Name"] = "Burst Strike Low Level", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = GaugeData1[1] >= MaxCartridges or (HasBloodfest and BloodfestCD < 20), ["OtherCheck"] = not HasDoubleDown
 		},
 		{
-			["Type"] = 1, ["Name"] = "Burst Strike High Level", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = (GaugeData1[1] >= MaxCartridges and Bloodfest.cd > 20) or not Bloodfest.isoncd or Bloodfest.cd > 100, ["OtherCheck"] = HasBloodfest
+			["Type"] = 1, ["Name"] = "Burst Strike High Level", ["ID"] = 16162, ["Range"] = 3, ["TargetCast"] = true, ["GaugeCheck"] = (GaugeData1[1] >= MaxCartridges and BloodfestCD ~= 0 and BloodfestCD < 100) or BloodfestCD < 20, ["OtherCheck"] = HasDoubleDown
 		},
 		{
 			["Type"] = 1, ["Name"] = "Jugular Rip", ["ID"] = 16156, ["Range"] = 3, ["TargetCast"] = true,
@@ -245,11 +246,11 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 		},
 		{
 			["Type"] = 1, ["Name"] = "Danger Zone", ["ID"] = 16144, ["Range"] = 3, ["TargetCast"] = true,
-			["OtherCheck"] = NoMercy.isoncd and NoMercy.cd < 40,
+			["OtherCheck"] = not NoMercySoon,
 		},
 		{
 			["Type"] = 1, ["Name"] = "Blasting Zone", ["ID"] = 16165, ["Range"] = 3, ["TargetCast"] = true,
-			["OtherCheck"] = NoMercy.isoncd and NoMercy.cd < 40,
+			["OtherCheck"] = not NoMercySoon,
 		},
 		{
 			["Type"] = 1, ["Name"] = "No Mercy", ["ID"] = 16138, ["Range"] = 0, ["TargetCast"] = false, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["OtherCheck"] = PlayerInCombat == true,

--- a/PVE_GUNBREAKER_DT.lua
+++ b/PVE_GUNBREAKER_DT.lua
@@ -264,6 +264,9 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 			["Type"] = 1, ["Name"] = "Nebula", ["ID"] = 16148, ["Range"] = 0, ["TargetCast"] = false, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["OtherCheck"] = PlayerHP < 50 and PlayerInCombat == true,
 		},
 		{
+			["Type"] = 1, ["Name"] = "Great Nebula", ["ID"] = 36935, ["Range"] = 0, ["TargetCast"] = false, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["OtherCheck"] = PlayerHP < 50 and PlayerInCombat == true,
+		},
+		{
 			["Type"] = 1, ["Name"] = "Aurora", ["ID"] = 16151, ["Range"] = 0, ["TargetCast"] = false, ["Buff"] = self.TargetBuff2(Player,1835,0,"Missing",PlayerID), ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["OtherCheck"] = PlayerHP < 65 and PlayerInCombat == true,
 		},
 		{


### PR DESCRIPTION
PR:
- Adds trajectory
- Adds lion heart combo
- Adds fated brand

Rotational improvements:
- Holds some single target cooldowns for better No mercy bursts (Gnashing fang, blasting zone.) If DDBurn is on, also DoubleDown and BowShock.
- Burns burst strike for bloodfest, at high level