### PR TITLE
sch rotation fixes, dawntrail abilities

### DIFF
--- a/PVE_SCHOLAR_DT.lua
+++ b/PVE_SCHOLAR_DT.lua
@@ -158,9 +158,14 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 	local SkillList = {
         
         -- Bigger Heals
-		{
-			["Type"] = 3, ["Name"] = "Excogitation", ["ID"] = 7434, ["Range"] = 30, ["TargetCast"] = true, ["HPAbove"] = 55, ["HP"] = 99, ["PartyOnly"] = true, ["RequiredClassType"] = 1,
+        {
+            ["Type"] = 3, ["Name"] = "Recitation", ["ID"] = 16542, ["Range"] = 30, ["TargetCast"] = false, ["HP"] = 99, ["PartyOnly"] = true,
 			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == true,
+			["OtherActionCooldownCheck"] = { ["ID"] = 7434, ["Time"] = 10, }
+        },
+		{
+			["Type"] = 3, ["Name"] = "Excogitation Tank", ["ID"] = 7434, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 99, ["PartyOnly"] = true, ["RequiredClassType"] = 1,
+			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
 		},
 		{
 			["Type"] = 3, ["Name"] = "Protraction", ["ID"] = 25867, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 70, ["PartyOnly"] = true, ["RequiredClassType"] = 1,
@@ -173,8 +178,8 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["LastActionTimeout"] = "Lustrate", ["LastActionTime"] = 2000,
 		},
 		{
-			["Type"] = 3, ["Name"] = "Physick", ["ID"] = 190, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 60, ["PartyOnly"] = false,
-			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
+			["Type"] = 3, ["Name"] = "Physick", ["ID"] = 190, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 60, ["PartyOnly"] = false, 
+			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerLevel < 30,
 		},
         {
             ["Type"] = 2, ["Name"] = "Indomitability", ["ID"] = 3583, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,50,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2) and PlayerInCombat == true,
@@ -193,10 +198,25 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
         },
         {
+            ["Type"] = 2, ["Name"] = "Seraphism", ["ID"] = 37014, ["Range"] = 50, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(50,70,nil,Data.EntityListSorted.PartySelf,CurrentPetData) >= (PartySize/2) and PlayerInCombat == true,
+            ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
+        },
+        {
             ["Type"] = 2, ["Name"] = "Indomitability", ["ID"] = 3583, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,50,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2) and PlayerInCombat == true,
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
         },
-
+		-- AOE
+        {
+            ["Type"] = 1, ["Name"] = "Baneful Impaction", ["ID"] = 37012, ["Range"] = 25, ["TargetCast"] = true, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DPS") == 1 and self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false,
+        },
+        {
+            ["Type"] = 2, ["Name"] = "Art of War", ["ID"] = 16539, ["Range"] = 0, ["TargetCast"] = false, ["AOECount"] = 2, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DPS") == 1, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false,
+            ["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, }, ["Level"] = self.SkillAccessCheck(16539,25866,PlayerLevel), 
+        },
+        {
+            ["Type"] = 2, ["Name"] = "Art of War II", ["ID"] = 25866, ["Range"] = 0, ["TargetCast"] = false, ["AOECount"] = 2, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DPS") == 1 and self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false,
+            ["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, }, ["Level"] = self.SkillAccessCheck(25866,nil,PlayerLevel), 
+        },
         -- Smaller Heals
 		{
 			["Type"] = 3, ["Name"] = "Esuna", ["ID"] = 7568, ["Range"] = 30, ["TargetCast"] = true, ["PartyOnly"] = false, ["Dispellable"] = true, ["OtherCheck"] = PlayerMoving == false,
@@ -204,28 +224,33 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 		},
 		{
 			["Type"] = 3, ["Name"] = "Physick", ["ID"] = 190, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 80, ["PartyOnly"] = false, ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
-			["Buff2"] = { ["Target"] = nil, ["BuffID"] = 1220, ["Time"] = -1, ["Type"] = "Missing", ["Owner"] = PlayerID, ["StackSize"] = nil, }
+			["Buff2"] = { ["Target"] = nil, ["BuffID"] = 1220, ["Time"] = -1, ["Type"] = "Missing", ["Owner"] = PlayerID, ["StackSize"] = nil, }, ["OtherCheck"] = PlayerLevel < 30,
 		},
 		{
 			["Type"] = 3, ["Name"] = "Adloquium", ["ID"] = 185, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 80, ["PartyOnly"] = false, ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
 			["Buff2"] = { ["Target"] = nil, ["BuffID"] = {1220,297}, ["Time"] = -1, ["Type"] = "Missing", ["Owner"] = PlayerID, ["StackSize"] = nil, }
+			["OtherCheck"] = PlayerLevel < 62,
 		},
         {
             ["Type"] = 2, ["Name"] = "Consolation", ["ID"] = 16546, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,80,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2),
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["LastActionTimeout"] = "Consolation", ["LastActionTime"] = 2000,
         },
         {
-            ["Type"] = 2, ["Name"] = "Succor", ["ID"] = 186, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,80,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2),
+            ["Type"] = 2, ["Name"] = "Succor", ["ID"] = 186, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,80,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2) and PartySize > 1 and PlayerLevel < 52,
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
         },
         {
-			["Type"] = 3, ["Name"] = "Sacred Soil", ["ID"] = 188, ["Range"] = 30, ["TargetCast"] = true, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DPS") == 1, 
+			["Type"] = 3, ["Name"] = "Sacred Soil", ["ID"] = 188, ["Range"] = 30, ["TargetCast"] = true, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"Heals") == 1, 
             ["AOECount"] = (PartySize/2), ["AOEType"] = { ["Filter"] = "PartySelf", ["Name"] = "Circle", ["AOERange"] = 13, ["BelowHP"] = 70, ["MaxDistance"] = 30, },
         },
 
         {
-            ["Type"] = 3, ["Name"] = "Aetherpact", ["ID"] = 7437, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 40, ["PartyOnly"] = true,
+            ["Type"] = 3, ["Name"] = "Aetherpact Tank", ["ID"] = 7437, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 40, ["PartyOnly"] = true,
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == true, ["RequiredClassType2"] = "Tank",
+        },
+        {
+            ["Type"] = 3, ["Name"] = "Aetherpact Self", ["ID"] = 7437, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 50,
+            ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == true and PartySize == 1, 
         },
         {
             ["Type"] = 2, ["Name"] = "Protraction", ["ID"] = 25867, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 60, ["PartyOnly"] = true,
@@ -235,20 +260,19 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
             ["Type"] = 3, ["Name"] = "Protraction", ["ID"] = 25867, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 60, ["PartyOnly"] = true,
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == true,
         },
-
         {
             ["Type"] = 2, ["Name"] = "Expedient", ["ID"] = 25868, ["Range"] = 30, ["TargetCast"] = false,
-            ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == true and (PlayerMoving == true or PlayerHP < 70),
+			["OtherCheck"] = self.PartyBelowHP(30,60,nil,Data.EntityListSorted.PartySelf,CurrentPetData) >= (PartySize/2) and PlayerInCombat == true,
+            ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1 and self.GetSettingsValue(ClassTypeID,"CDs") == 1,
         },
         {
             ["Type"] = 2, ["Name"] = "Dissipation", ["ID"] = 3587, ["Range"] = 30, ["TargetCast"] = false, ["GaugeCheck"] = GaugeData1[1] == 0, ["OtherCheck"] = AetherflowCD > 15,
-            ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["OtherCheck"] = PlayerInCombat == true,
+            ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["OtherCheck"] = PlayerInCombat == true, ["PartyOnly"] = true,
         },
         {
-            ["Type"] = 3, ["Name"] = "Excogitation", ["ID"] = 7434, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 70, ["HPAbove"] = 55, 
-            ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["OtherCheck"] = PlayerInCombat == true,
+            ["Type"] = 3, ["Name"] = "Excogitation Self", ["ID"] = 7434, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 99, 
+            ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["OtherCheck"] = PlayerInCombat == true and PartySize == 1,
         },
-
         {
             ["Type"] = 2, ["Name"] = "Summon Seraph", ["ID"] = 16545, ["Range"] = 30, ["TargetCast"] = false, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"Pet") == 1,
             ["OtherCheck"] = CurrentPet ~= 8227 and PlayerInCombat == true and self.PartyBelowHP(35,90,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2) and PlayerInCombat == true,
@@ -259,25 +283,16 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
             ["LastActionTimeout"] = "PetSummon", ["LastActionTime"] = 5000, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"Pet") == 1,
         },
         {
-            ["Type"] = 2, ["Name"] = "Aetherflow", ["ID"] = 166, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = GaugeData1[1] == 0 or PlayerMP < 60,
-        },
-        {
-            ["Type"] = 2, ["Name"] = "Aetherflow", ["ID"] = 166, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = GaugeData1[1] == 0 or PlayerMP < 60,
+            ["Type"] = 2, ["Name"] = "Aetherflow", ["ID"] = 166, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = GaugeData1[1] == 0 or PlayerMP < 30,
         },
 
         -- Damage
+		--[[
         {
             ["Type"] = 1, ["Name"] = "Energy Drain", ["ID"] = 167, ["Range"] = 25, ["TargetCast"] = true, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DPS") == 1, ["OtherCheck"] = PlayerHP < 50,
         },
+		--]]
 
-        {
-            ["Type"] = 2, ["Name"] = "Art of War", ["ID"] = 16539, ["Range"] = 0, ["TargetCast"] = false, ["AOECount"] = 2, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DPS") == 1, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false,
-            ["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, }, ["Level"] = self.SkillAccessCheck(16539,25866,PlayerLevel), 
-        },
-        {
-            ["Type"] = 2, ["Name"] = "Art of War II", ["ID"] = 25866, ["Range"] = 0, ["TargetCast"] = false, ["AOECount"] = 2, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DPS") == 1, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"AOE") == 1 and AOETimeout == false,
-            ["AOEType"] = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 5, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, }, ["Level"] = self.SkillAccessCheck(25866,nil,PlayerLevel), 
-        },
 
         {
             ["Type"] = 1, ["Name"] = "Bio", ["ID"] = 17864, ["Range"] = 25, ["TargetCast"] = true, ["Level"] = self.SkillAccessCheck(17864,17865,PlayerLevel), ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"DPS") == 1, ["Buff"] = ShouldApplyBio == true, ["DOTCheck"] = true,
@@ -324,17 +339,7 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
             ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["Buff2"] = { ["BuffID"] = {297}, ["Time"] = 3, ["Type"] = "Has", ["Owner"] = PlayerID, }
         },
         {
-            ["Type"] = 2, ["Name"] = "Recitation", ["ID"] = 16542, ["Range"] = 30, ["TargetCast"] = false, ["OtherCheck"] = PlayerInCombat == true and PlayerMP < 60,
-            ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1,
-        },
-
-
-        {
-            ["Type"] = 2, ["Name"] = "Thin Air", ["ID"] = 7430, ["Range"] = 30, ["TargetCast"] = false, ["OtherCheck"] = PlayerInCombat == true and PlayerMP < 30,
-            ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1,
-        },
-        {
-            ["Type"] = 2, ["Name"] = "Lucid Dreaming", ["ID"] = 7562, ["Range"] = 30, ["TargetCast"] = false, ["OtherCheck"] = PlayerInCombat == true and PlayerMP < 70,
+            ["Type"] = 2, ["Name"] = "Lucid Dreaming", ["ID"] = 7562, ["Range"] = 30, ["TargetCast"] = false, ["OtherCheck"] = PlayerInCombat == true and PlayerMP < 85,
             ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1,
         },
     }

--- a/PVE_SCHOLAR_DT.lua
+++ b/PVE_SCHOLAR_DT.lua
@@ -103,8 +103,7 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
     local AetherflowCD = self.GetActionCD(166,true)
 	
 	local AOEType = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 35, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, }
-	local EnemiesAroundSelf = self.EntityInCount(AOEType)
-	local InTrashMobs = EnemiesAroundSelf >= 2
+	local InTrashMobs = PartyAggroCount >= 2
 	
 	-- Avoid stacking fey illumination and expedient
 	local HasPartyMit = self.TargetBuff2(Player,317,0,"Has",PlayerID) or self.TargetBuff2(Player,2711,0,"Has",PlayerID)

--- a/PVE_SCHOLAR_DT.lua
+++ b/PVE_SCHOLAR_DT.lua
@@ -165,33 +165,41 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
         },
 		{
 			["Type"] = 3, ["Name"] = "Excogitation Tank", ["ID"] = 7434, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 99, ["PartyOnly"] = true, ["RequiredClassType"] = 1,
-			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
+			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == false or PartyAggroCount > 1,
+			["Buff2"] = { ["Target"] = nil, ["BuffID"] = 1220, ["Time"] = -1, ["Type"] = "Missing", ["Owner"] = PlayerID, ["StackSize"] = nil, }
 		},
 		{
 			["Type"] = 3, ["Name"] = "Protraction", ["ID"] = 25867, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 70, ["PartyOnly"] = true, ["RequiredClassType"] = 1,
 			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == true,
 			["Buff2"] = { ["Target"] = nil, ["BuffID"] = 1220, ["Time"] = -1, ["Type"] = "Missing", ["Owner"] = PlayerID, ["StackSize"] = nil, }
 		},
-
+        {
+            ["Type"] = 2, ["Name"] = "Fey Blessing", ["ID"] = 16543, ["Range"] = 20, ["TargetCast"] = false, ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
+            ["OtherCheck"] = CurrentPetPOS ~= nil and self.PartyBelowHP(20,70,nil,Data.EntityListSorted.PartySelf,CurrentPetData) >= (PartySize/2) and PlayerInCombat == true,
+        },
+        {
+            ["Type"] = 2, ["Name"] = "Indomitability", ["ID"] = 3583, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,70,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2) and PlayerInCombat == true and PartyAggroCount == 1,
+            ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, 
+			["LastActionTimeout"] = "Indom", ["LastActionTime"] = 6000,
+        },
+        {
+			["Type"] = 3, ["Name"] = "Sacred Soil", ["ID"] = 188, ["Range"] = 30, ["TargetCast"] = true,
+            ["AOECount"] = (PartySize/2), ["AOEType"] = { ["Filter"] = "PartySelf", ["Name"] = "Circle", ["AOERange"] = 13, ["BelowHP"] = 70, ["MaxDistance"] = 30, },
+			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
+			["OtherCheck"] = PlayerInCombat == true,
+        },
 		{
-			["Type"] = 3, ["Name"] = "Lustrate", ["ID"] = 189, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 60, ["PartyOnly"] = false,
-			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["LastActionTimeout"] = "Lustrate", ["LastActionTime"] = 2000,
+			["Type"] = 3, ["Name"] = "Lustrate", ["ID"] = 189, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 50, ["PartyOnly"] = false,
+			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["LastActionTimeout"] = "Lustrate", ["LastActionTime"] = 4000,
+			["OtherCheck"] = PlayerInCombat == true,
 		},
 		{
 			["Type"] = 3, ["Name"] = "Physick", ["ID"] = 190, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 60, ["PartyOnly"] = false, 
 			["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerLevel < 30,
 		},
         {
-            ["Type"] = 2, ["Name"] = "Indomitability", ["ID"] = 3583, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,50,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2) and PlayerInCombat == true,
+            ["Type"] = 2, ["Name"] = "Fey Illumination", ["ID"] = 16538, ["Range"] = 30, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(30,80,nil,Data.EntityListSorted.PartySelf,CurrentPetData) >= (PartySize/2) and PlayerInCombat == true,
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
-        },
-        {
-            ["Type"] = 2, ["Name"] = "Fey Illumination", ["ID"] = 16538, ["Range"] = 30, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(30,60,nil,Data.EntityListSorted.PartySelf,CurrentPetData) >= (PartySize/2) and PlayerInCombat == true,
-            ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
-        },
-        {
-            ["Type"] = 2, ["Name"] = "Fey Blessing", ["ID"] = 16543, ["Range"] = 20, ["TargetCast"] = false, ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
-            ["OtherCheck"] = CurrentPetPOS ~= nil and self.PartyBelowHP(20,65,nil,Data.EntityListSorted.PartySelf,CurrentPetData) >= (PartySize/2),
         },
         {
             ["Type"] = 2, ["Name"] = "Whispering Dawn", ["ID"] = 16537, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,70,nil,Data.EntityListSorted.PartySelf,CurrentPetData) >= (PartySize/2) and PlayerInCombat == true,
@@ -199,10 +207,6 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
         },
         {
             ["Type"] = 2, ["Name"] = "Seraphism", ["ID"] = 37014, ["Range"] = 50, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(50,70,nil,Data.EntityListSorted.PartySelf,CurrentPetData) >= (PartySize/2) and PlayerInCombat == true,
-            ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
-        },
-        {
-            ["Type"] = 2, ["Name"] = "Indomitability", ["ID"] = 3583, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,50,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2) and PlayerInCombat == true,
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
         },
 		-- AOE
@@ -228,24 +232,20 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 		},
 		{
 			["Type"] = 3, ["Name"] = "Adloquium", ["ID"] = 185, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 80, ["PartyOnly"] = false, ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
-			["Buff2"] = { ["Target"] = nil, ["BuffID"] = {1220,297}, ["Time"] = -1, ["Type"] = "Missing", ["Owner"] = PlayerID, ["StackSize"] = nil, }
+			["Buff2"] = { ["Target"] = nil, ["BuffID"] = {1220,297}, ["Time"] = -1, ["Type"] = "Missing", ["Owner"] = PlayerID, ["StackSize"] = nil, },
 			["OtherCheck"] = PlayerLevel < 62,
 		},
         {
             ["Type"] = 2, ["Name"] = "Consolation", ["ID"] = 16546, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,80,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2),
-            ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["LastActionTimeout"] = "Consolation", ["LastActionTime"] = 2000,
-        },
-        {
-            ["Type"] = 2, ["Name"] = "Succor", ["ID"] = 186, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,80,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2) and PartySize > 1 and PlayerLevel < 52,
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
         },
         {
-			["Type"] = 3, ["Name"] = "Sacred Soil", ["ID"] = 188, ["Range"] = 30, ["TargetCast"] = true, ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"Heals") == 1, 
-            ["AOECount"] = (PartySize/2), ["AOEType"] = { ["Filter"] = "PartySelf", ["Name"] = "Circle", ["AOERange"] = 13, ["BelowHP"] = 70, ["MaxDistance"] = 30, },
+            ["Type"] = 2, ["Name"] = "Succor", ["ID"] = 186, ["Range"] = 15, ["TargetCast"] = false, ["OtherCheck"] = self.PartyBelowHP(15,50,nil,Data.EntityListSorted.PartySelf) >= (PartySize/2) and PartySize > 1 and (PlayerLevel < 52 or GaugeData1[1] == 0),
+            ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1,
+			["LastActionTimeout"] = "Indom", ["LastActionTime"] = 6000,
         },
-
         {
-            ["Type"] = 3, ["Name"] = "Aetherpact Tank", ["ID"] = 7437, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 40, ["PartyOnly"] = true,
+            ["Type"] = 3, ["Name"] = "Aetherpact Tank", ["ID"] = 7437, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 50, ["PartyOnly"] = true,
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == true, ["RequiredClassType2"] = "Tank",
         },
         {
@@ -253,21 +253,21 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == true and PartySize == 1, 
         },
         {
-            ["Type"] = 2, ["Name"] = "Protraction", ["ID"] = 25867, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 60, ["PartyOnly"] = true,
+            ["Type"] = 2, ["Name"] = "Protraction Tank", ["ID"] = 25867, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 60, ["PartyOnly"] = true,
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == true, ["RequiredClassType2"] = "Tank",
         },
         {
-            ["Type"] = 3, ["Name"] = "Protraction", ["ID"] = 25867, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 60, ["PartyOnly"] = true,
-            ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == true,
+            ["Type"] = 3, ["Name"] = "Protraction Self", ["ID"] = 25867, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 60, ["PartyOnly"] = true,
+            ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1, ["OtherCheck"] = PlayerInCombat == true and PartySize == 1,
         },
         {
             ["Type"] = 2, ["Name"] = "Expedient", ["ID"] = 25868, ["Range"] = 30, ["TargetCast"] = false,
-			["OtherCheck"] = self.PartyBelowHP(30,60,nil,Data.EntityListSorted.PartySelf,CurrentPetData) >= (PartySize/2) and PlayerInCombat == true,
+			["OtherCheck"] = self.PartyBelowHP(30,70,nil,Data.EntityListSorted.PartySelf,CurrentPetData) >= (PartySize/2) and PlayerInCombat == true,
             ["SettingValue"] = HealTimeout == false and self.GetSettingsValue(ClassTypeID,"Heals") == 1 and self.GetSettingsValue(ClassTypeID,"CDs") == 1,
         },
         {
-            ["Type"] = 2, ["Name"] = "Dissipation", ["ID"] = 3587, ["Range"] = 30, ["TargetCast"] = false, ["GaugeCheck"] = GaugeData1[1] == 0, ["OtherCheck"] = AetherflowCD > 15,
-            ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["OtherCheck"] = PlayerInCombat == true, ["PartyOnly"] = true,
+            ["Type"] = 2, ["Name"] = "Dissipation", ["ID"] = 3587, ["Range"] = 30, ["TargetCast"] = false, ["GaugeCheck"] = GaugeData1[1] == 0, ["OtherCheck"] = AetherflowCD > 15 and PlayerInCombat == true,
+            ["SettingValue"] = self.GetSettingsValue(ClassTypeID,"CDs") == 1, ["PartyOnly"] = true,
         },
         {
             ["Type"] = 3, ["Name"] = "Excogitation Self", ["ID"] = 7434, ["Range"] = 30, ["TargetCast"] = true, ["HP"] = 99, 

--- a/PVE_SCHOLAR_DT.lua
+++ b/PVE_SCHOLAR_DT.lua
@@ -102,7 +102,6 @@ function Profile:SkillTable(Data,Target,ClassTypeID)
 	
     local AetherflowCD = self.GetActionCD(166,true)
 	
-	local AOEType = { ["Filter"] = "Enemy", ["Name"] = "Circle", ["TargetPoint"] = PlayerPOS, ["AOERange"] = 35, ["MaxDistance"] = 0, ["LineWidth"] = 0, ["Angle"] = 0, }
 	local InTrashMobs = PartyAggroCount >= 2
 	
 	-- Avoid stacking fey illumination and expedient


### PR DESCRIPTION
Updates SCH rotation in many ways, to:
- Make it a chad healer at high level
- Spread out cooldowns a bit
- Use aetherflow charges smartly, using Recitation Excog for trash pulls <-> Indom for bosses

Adds the dawntrail sch abilities, baneful impaction / concitation / seraphism + related abilities.
